### PR TITLE
Added a props called "hideNoResults" to hide "No Results" Dropdown

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,11 +101,15 @@ class GooglePlacesSuggest extends Component {
 
   renderNoResults() {
     const {textNoResults} = this.props
-    return (
-      <li className="placesSuggest_suggest">
-        {textNoResults}
-      </li>
-    )
+    if(this.props.hideNoResults != undefined && this.props.hideNoResults === true) {
+      return;
+    } else {
+        return (
+          <li className="placesSuggest_suggest">
+            {textNoResults}
+          </li>
+        )
+      }
   }
 
   renderDefaultSuggest(suggest) {


### PR DESCRIPTION
Added a props called "hideNoResults" to hide "No Results" Dropdown when the props receives a value as true(Boolean value) that will hide the No results text.

<GooglePlacesSuggest
        googleMaps={googleMaps}
        onSelectSuggest={this.handleSelectSuggest}
        search={search}
        hideNoResults={true}
      >
By default "No results" text will be there on the suggestion dropdown.