### PR TITLE
issue #20 -  added the suggestion as argument to onSelectSuggest

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ class GooglePlacesSuggest extends React.Component {
       },
       () => {
         this.geocodePrediction(suggest.description, result => {
-          onSelectSuggest(result)
+          onSelectSuggest(result, suggestion)
         })
       }
     )

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ class GooglePlacesSuggest extends React.Component {
       },
       () => {
         this.geocodePrediction(suggest.description, result => {
-          onSelectSuggest(result, suggestion)
+          onSelectSuggest(result, suggest)
         })
       }
     )


### PR DESCRIPTION
added the suggestion as argument to onSelectSuggest

Previously when a suggestion is selected, the callback only gets the geocoding result, and never the suggestion itself. Since the result only contains the address information, and not the name of the place itself, it would be useful to return to the callback the suggestion, so the parent can use the suggest.description