### PR TITLE
Fixed font-weight highlighting when using arrow keys

### DIFF
--- a/src/components/Prediction/index.js
+++ b/src/components/Prediction/index.js
@@ -7,11 +7,11 @@ const Match = styled.span`
 `
 
 const Prediction = ({item}) => {
-  const {description, matched_substrings} = item
+  const {description, structured_formatting} = item
   const firstMatchedString =
-    matched_substrings &&
-    matched_substrings.length > 0 &&
-    matched_substrings.shift()
+    structured_formatting &&
+    structured_formatting.main_text_matched_substrings.length > 0 &&
+    structured_formatting.main_text_matched_substrings[0]
   let labelParts = null
 
   if (firstMatchedString) {
@@ -45,12 +45,14 @@ const Prediction = ({item}) => {
 Prediction.propTypes = {
   item: PropTypes.shape({
     description: PropTypes.string,
-    matched_substrings: PropTypes.arrayOf(
-      PropTypes.shape({
-        length: PropTypes.number.isRequired,
-        offset: PropTypes.number.isRequired,
-      })
-    ),
+    structured_formatting: PropTypes.shape({
+      main_text_matched_substrings: PropTypes.arrayOf(
+        PropTypes.shape({
+          length: PropTypes.number.isRequired,
+          offset: PropTypes.number.isRequired,
+        })
+      ),
+    }),
   }).isRequired,
 }
 

--- a/src/components/Prediction/index.test.js
+++ b/src/components/Prediction/index.test.js
@@ -6,7 +6,9 @@ const LabelFixture = (
   <Label
     item={{
       description: "Toulouse, France",
-      matched_substrings: [{length: 3, offset: 0}],
+      structured_formatting: {
+        main_text_matched_substrings: [{length: 3, offset: 0}],
+      },
     }}
   />
 )
@@ -15,7 +17,9 @@ const LabelMatchedFixture = (
   <Label
     item={{
       description: "Toulouse, France",
-      matched_substrings: [{length: 3, offset: 0}],
+      structured_formatting: {
+        main_text_matched_substrings: [{length: 3, offset: 0}],
+      },
     }}
   />
 )


### PR DESCRIPTION
Addresses: Issue https://github.com/xuopled/react-google-places-suggest/issues/33

I noticed that the `matched_substrings` value worked when typing in the input box but was empty once the arrow keys are used. 

By changing the property to `structured_formatting.main_text_matched_substrings` I was able to access the respective properties when typing and using arrow keys.

Repository Question: I made my code changes in the `src` folder and updated the corresponding test. I noticed similar/duplicate code is being maintained in the `es` folder. Should contributors make code changes in both spots?

Fixed 🛠 
![fix font weight bug](https://user-images.githubusercontent.com/8575456/50731824-87bfa980-1133-11e9-84b9-d3c34ae4f990.gif)
