### PR TITLE
Added onNoResult callback to GooglePlacesSuggest

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ export default class GoogleSuggest extends React.Component {
         console.log(geocodedPrediction, originalPrediction) // eslint-disable-line
         this.setState({search: "", value: geocodedPrediction.formatted_address})
     }
+    
+    handleNoResult = () => {
+        console.log('No results for ', this.state.search)
+    }
 
     render() {
         const {search, value} = this.state
@@ -67,6 +71,7 @@ export default class GoogleSuggest extends React.Component {
                                 // https://developers.google.com/maps/documentation/javascript/reference?hl=fr#AutocompletionRequest
                             }}
                             // Optional props
+                            onNoResult={this.handleNoResult}
                             onSelectSuggest={this.handleSelectSuggest}
                             textNoResults="My custom no results text" // null or "" if you want to disable the no results item
                             customRender={prediction => (
@@ -101,6 +106,7 @@ See [Demo page][github-page]
 | Name                  | PropType | Description                                                                                                                   | Example                                                                                             |
 | --------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | googleMaps            | object   | injected by `react-google-maps-loader`                                                                                        | -                                                                                                   |
+| onNoResult            | function | Handle no results when enter key is pressed                                                                                                     | `(geocodedPrediction, originalPrediction) => {console.log(geocodedPrediction, originalPrediction)}` |
 | onSelectSuggest       | function | Handle click on suggest                                                                                                       | `(geocodedPrediction, originalPrediction) => {console.log(geocodedPrediction, originalPrediction)}` |
 | customRender          | function | Customize list item                                                                                                           | `prediction => prediction ? prediction.description : "no results"`                                  |
 | customContainerRender | function | Customize list                                                                                                                | `items => <CustomWrapper>{items.map(item => <ItemWrapper>{item.description}</ItemWrapper>)}         |

--- a/demo/src/components/GoogleSuggest.js
+++ b/demo/src/components/GoogleSuggest.js
@@ -19,6 +19,10 @@ class GoogleSuggest extends React.Component {
     this.setState({search: "", value: suggest.formatted_address})
   }
 
+  handleNoResult() {
+    alert(this.state.search) // eslint-disable-line
+  }
+
   render() {
     const {search, value} = this.state
     return (
@@ -34,6 +38,7 @@ class GoogleSuggest extends React.Component {
                 autocompletionRequest={{input: search}}
                 googleMaps={googleMaps}
                 onSelectSuggest={this.handleSelectSuggest.bind(this)}
+                onNoResult={this.handleNoResult.bind(this)}
               >
                 <input
                   type="text"

--- a/demo/src/components/GoogleSuggest.js
+++ b/demo/src/components/GoogleSuggest.js
@@ -38,7 +38,6 @@ class GoogleSuggest extends React.Component {
                 autocompletionRequest={{input: search}}
                 googleMaps={googleMaps}
                 onSelectSuggest={this.handleSelectSuggest.bind(this)}
-                onNoResult={this.handleNoResult.bind(this)}
               >
                 <input
                   type="text"

--- a/src/index.js
+++ b/src/index.js
@@ -125,6 +125,10 @@ class GooglePlacesSuggest extends React.Component {
           this.focusPrediction(focusedPredictionIndex + 1)
         }
       }
+    } else if (e.key === "Enter") {
+      const {onNoResult} = this.props
+
+      onNoResult()
     }
   }
 
@@ -172,6 +176,7 @@ class GooglePlacesSuggest extends React.Component {
 GooglePlacesSuggest.propTypes = {
   children: PropTypes.any.isRequired,
   googleMaps: PropTypes.object.isRequired,
+  onNoResult: PropTypes.func,
   onSelectSuggest: PropTypes.func,
   customContainerRender: PropTypes.func,
   customRender: PropTypes.func,

--- a/src/index.js
+++ b/src/index.js
@@ -187,6 +187,7 @@ GooglePlacesSuggest.propTypes = {
 }
 
 GooglePlacesSuggest.defaultProps = {
+  onNoResult: () => {},
   onSelectSuggest: () => {},
   textNoResults: "No results",
 }


### PR DESCRIPTION
- Added an optional `onNoResult` callback function which is called when no results are found upon hitting enter. 
- Added example `onNoResult` callback to the ReadMe.

![no-results-callback](https://user-images.githubusercontent.com/8575456/53972115-cc2fdd00-40c3-11e9-8f3b-648ca3dfe596.gif)

Feature for #35 