### PR TITLE
Fix: Prediction text wrap

### DIFF
--- a/demo/src/components/GoogleSuggest.js
+++ b/demo/src/components/GoogleSuggest.js
@@ -38,6 +38,7 @@ class GoogleSuggest extends React.Component {
                 autocompletionRequest={{input: search}}
                 googleMaps={googleMaps}
                 onSelectSuggest={this.handleSelectSuggest.bind(this)}
+                onNoResult={this.handleNoResult.bind(this)}
               >
                 <input
                   type="text"

--- a/src/components/Prediction/index.js
+++ b/src/components/Prediction/index.js
@@ -4,14 +4,10 @@ import styled from "styled-components"
 
 const Match = styled.span`
   font-weight: bold;
-  width: 100%;
-  display: block;
 `
 const UpperDiv = styled.div`
+  text-align: left;
   width: 100%;
-`
-const OuterSpan = styled.span`
-  display: inline;
 `
 
 const Prediction = ({item}) => {
@@ -38,11 +34,11 @@ const Prediction = ({item}) => {
   return (
     <UpperDiv>
       {labelParts ? (
-        <OuterSpan>
+        <span>
           {labelParts.before}
           <Match>{labelParts.match}</Match>
           {labelParts.after}
-        </OuterSpan>
+        </span>
       ) : (
         description
       )}


### PR DESCRIPTION
- Removed `display: block;` from `Match` styled-component
- Removed `OuterSpan` styled-component since `display: inline;` is default with span

- Fixed GoogleSuggest demo for noResult

![prediction-highlight](https://user-images.githubusercontent.com/8575456/54040834-e503c580-418b-11e9-8ab5-9a96786f1bd2.gif)

cc: @saikatharryc can you verify that this works for #37 #38 
