### PR TITLE
Add onStatusUpdate callback prop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 
 ## Demo Development Server
 
-- `npm run demo:start` will run a development server with the component's demo app at [http://localhost:1190](http://localhost:1190) with hot module reloading.
+- `npm run start` will run a development server with the component's demo app at [http://localhost:1190](http://localhost:1190) with hot module reloading.
 
 ## Linting
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ export default class GoogleSuggest extends React.Component {
         console.log('No results for ', this.state.search)
     }
 
+    handleStatusUpdate = (status) => {
+        console.log(status)
+    }
+
     render() {
         const {search, value} = this.state
         return (
@@ -73,6 +77,7 @@ export default class GoogleSuggest extends React.Component {
                             // Optional props
                             onNoResult={this.handleNoResult}
                             onSelectSuggest={this.handleSelectSuggest}
+                            onStatusUpdate={this.handleStatusUpdate}
                             textNoResults="My custom no results text" // null or "" if you want to disable the no results item
                             customRender={prediction => (
                                 <div className="customWrapper">
@@ -106,10 +111,11 @@ See [Demo page][github-page]
 | Name                   | PropType | Description                                                                                                                   | Example                                                                                             |
 | ---------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | googleMaps             | object   | injected by `react-google-maps-loader`                                                                                        | -                                                                                                   |
-| onNoResult             | function | Handle no results when enter key is pressed                                                                                                     | `(geocodedPrediction, originalPrediction) => {console.log(geocodedPrediction, originalPrediction)}` |
+| onNoResult             | function | Handle no results when enter key is pressed                                                                                   | `(geocodedPrediction, originalPrediction) => {console.log(geocodedPrediction, originalPrediction)}` |
 | onSelectSuggest        | function | Handle click on suggest                                                                                                       | `(geocodedPrediction, originalPrediction) => {console.log(geocodedPrediction, originalPrediction)}` |
+| onStatusUpdate         | function | Handle places service status update                                                                                           | `status => {console.log(status)}`                                                                   |
 | customRender           | function | Customize list item                                                                                                           | `prediction => prediction ? prediction.description : "no results"`                                  |
-| customContainerRender  | function | Customize list                                                                                                                | `items => <CustomWrapper>{items.map(item => <ItemWrapper>{item.description}</ItemWrapper>)}         |
+| customContainerRender  | function | Customize list                                                                                                                | `items => <CustomWrapper>{items.map(item => <ItemWrapper>{item.description}</ItemWrapper>)}`        |
 | displayPoweredByGoogle | boolean  | Display the "Powered By Google" logo as required by the [Google Maps autocomplete terms and conditions](https://developers.google.com/maps/documentation/javascript/places-autocomplete#fig1). (defaults to true. Not included when using customContainerRender prop)
 | textNoResults          | String   | No results text, null to disable                                                                                              | `No results`                                                                                        |
 

--- a/demo/src/components/GoogleSuggest.js
+++ b/demo/src/components/GoogleSuggest.js
@@ -23,6 +23,10 @@ class GoogleSuggest extends React.Component {
     alert(this.state.search) // eslint-disable-line
   }
 
+  handleStatusUpdate(status) {
+    console.log(status) // eslint-disable-line
+  }
+
   render() {
     const {search, value} = this.state
     return (
@@ -39,6 +43,7 @@ class GoogleSuggest extends React.Component {
                 googleMaps={googleMaps}
                 onSelectSuggest={this.handleSelectSuggest.bind(this)}
                 onNoResult={this.handleNoResult.bind(this)}
+                onStatusUpdate={this.handleStatusUpdate}
               >
                 <input
                   type="text"

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,8 @@ class GooglePlacesSuggest extends React.Component {
 
     autocompleteService.getPlacePredictions(
       autocompletionRequest, // https://developers.google.com/maps/documentation/javascript/reference?hl=fr#AutocompletionRequest
-      predictions => {
+      (predictions, status) => {
+        this.props.onStatusUpdate(status)
         if (!predictions) {
           this.setState({open: true, predictions: []})
           return
@@ -180,6 +181,7 @@ GooglePlacesSuggest.propTypes = {
   googleMaps: PropTypes.object.isRequired,
   onNoResult: PropTypes.func,
   onSelectSuggest: PropTypes.func,
+  onStatusUpdate: PropTypes.func,
   customContainerRender: PropTypes.func,
   customRender: PropTypes.func,
   displayPoweredByGoogle: PropTypes.bool,
@@ -193,6 +195,7 @@ GooglePlacesSuggest.defaultProps = {
   displayPoweredByGoogle: true,
   onNoResult: () => {},
   onSelectSuggest: () => {},
+  onStatusUpdate: () => {},
   textNoResults: "No results",
 }
 


### PR DESCRIPTION
Relates to #47 

This PR adds an `onStatusUpdate` callback prop that receives the service status from the place API after each prediction. The full list of service statuses can be found [here].(https://developers.google.com/maps/documentation/javascript/reference/places-service#PlacesServiceStatus)

This is an example of what an `onStatusUpdate` prop might look like. Let me know if the name and functionality is consistent with the purpose of this library.