### PR TITLE
Check for undefined main_text_matched_substrings

### DIFF
--- a/src/components/Prediction/index.js
+++ b/src/components/Prediction/index.js
@@ -14,6 +14,7 @@ const Prediction = ({item}) => {
   const {description, structured_formatting} = item
   const firstMatchedString =
     structured_formatting &&
+    structured_formatting.main_text_matched_substrings &&
     structured_formatting.main_text_matched_substrings.length > 0 &&
     structured_formatting.main_text_matched_substrings[0]
   let labelParts = null


### PR DESCRIPTION
It can happen that structured_formatting.main_text_matched_substrings is undefined, e.g. if you search for "90 Imagumano Minamihiyoshi". This will result in an error in the Prediction component.